### PR TITLE
fix: double click to zoom pics in phone's browser (#1274)

### DIFF
--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -138,6 +138,15 @@ export default {
       this.lastX = null
       this.lastY = null
       this.lastTouchDistance = null
+      if (event.targetTouches.length < 2) {
+        setTimeout(() => {
+          this.touches = 0
+        }, 300)
+        this.touches++
+        if (this.touches > 1) {
+          this.zoomAuto(event)
+        }
+      }    
       event.preventDefault()
     },
     zoomAuto(event) {
@@ -151,6 +160,7 @@ export default {
         default:
         case 4:
           this.scale = 1
+          this.setCenter()
           break
       }
       this.setZoom()


### PR DESCRIPTION
fixed this : https://github.com/filebrowser/filebrowser/issues/1266

**Description**
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
